### PR TITLE
CICD設定を追加する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+orbs:
+  discord: antonioned/discord@0.1.0
+
+jobs:
+  test:
+    docker:
+      - image: cimg/go:1.19.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run: go get
+
+      - run: go test -cover -v ./...
+
+      - run: go build ./handler.go
+
+      - discord/status:
+          fail_only: true
+          failure_message: "Triggered User: **${CIRCLE_USERNAME}**\\nBranch: **${CIRCLE_BRANCH}**\\n\\nCircleCI テストに失敗しました。 JOB: **$CIRCLE_JOB**"
+          webhook: "${DISCORD_WEBHOOK}"
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - test:
+          context: kazuhito_m-products

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        golang: [1.19.4]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Golang env
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.golang }}
+
+      - name: Get lib
+        run: go get
+
+      - name: Run tests
+        run: go test -cover -v ./...
+
+      - name: Run build
+        run: go build ./handler.go
+
+      - name: Notify Discord
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook:
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+        if: failure()

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 GCP Cloud Build Notifier for Slack
 ==================================
 
+[![ci](https://github.com/kazuhito-m/gcp-cloudbuild-slack-notifier/actions/workflows/ci.yml/badge.svg)](https://github.com/kazuhito-m/gcp-cloudbuild-slack-notifier/actions/workflows/ci.yml)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/kazuhito-m/gcp-cloudbuild-slack-notifier/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/kazuhito-m/gcp-cloudbuild-slack-notifier/tree/main)
+
 GCP にて Cloud Build が実行された際に Slack に通知する、 Cloud Functions 用プログラム。
 
 ![Slack通知結果のスクリーンショット](doc/screenshot.png)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ https://cloud.google.com/cloud-build/docs/configure-third-party-notifications
 | GCSN_START_NOTIFY_DISABLE | [ ] | 開始時通知を無効化する。True:無効。                           |
 | GCSN_END_NOTIFY_DISABLE | [ ] | 終了時通知を無効化する。True:無効。                           |
 
-
-
-
-
 ### Requirement
 
 - GCPにプロジェクトが作成済みであること
@@ -47,10 +43,6 @@ https://cloud.google.com/cloud-build/docs/configure-third-party-notifications
 - ローカルから `gcloud` コマンドが発行できること
 - Slackに「Incoming Webhook」が登録されていること
     - WebhookのURLが解っていること
-
-#### 開発環境(言語)のバージョン
-
-対象の `golang` のバージョンは、 CIのファイルである `.circleci/config.yml`, `.github/workflows/ci.yml` を参照。
 
 ### gcloudコマンド(のスクリプト)でCloud Functionsに登録する場合
 
@@ -80,3 +72,7 @@ Cloud Buildの管理画面からTriggerを登録します。
 - 本家(このGitHubのリポジトリ)の更新に巻き込まれたくない場合は、Forkするか、「GCP Cloud Source Repositories」にソースをコピーするなどして下さい
 
 初回ビルド起動で、Cloud Functionsに `PubSubHandlerForCloudBuild` というFunctionが作成されれば成功です。
+
+## Prerequisite
+
+開発に使う `golang` のバージョンは、 CIのファイルである `.circleci/config.yml`, `.github/workflows/ci.yml` を参照。

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ https://cloud.google.com/cloud-build/docs/configure-third-party-notifications
 - Slackに「Incoming Webhook」が登録されていること
     - WebhookのURLが解っていること
 
+#### 開発環境(言語)のバージョン
+
+対象の `golang` のバージョンは、 CIのファイルである `.circleci/config.yml`, `.github/workflows/ci.yml` を参照。
+
 ### gcloudコマンド(のスクリプト)でCloud Functionsに登録する場合
 
 前述の前提を満たした状態で、以下のコマンドをbashコンソールから実行します。


### PR DESCRIPTION
ちょうど、他のプロジェクトでやっていた「CI/CDの設定」をそのまま持ってきて、CIが動くようにする。

テストとビルドを行い、失敗していればDiscordへと通知する。